### PR TITLE
Load different config depending on environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 assets/config.json
+assets/config_prod.json
 
 .firebase/
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'screens/screens.dart';
 
+const bool isProduction = bool.fromEnvironment('dart.vm.product');
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,8 +17,11 @@ void main() async {
   String sampleJobs = await loadSampleJobs();
   runApp(MyApp(config, sampleJobs));
 }
+
 Future<Map<String, dynamic>> loadConfig() async {
-  String configString = await rootBundle.loadString('assets/config.json');
+  // load different config if in production mode
+  String configFileName = isProduction ? 'assets/config_prod.json' : 'assets/config.json';
+  String configString = await rootBundle.loadString(configFileName);
   return jsonDecode(configString);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/config.json
+    - assets/config_prod.json
     - assets/sample_jobs.json
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
Hey Rivers! Nice work on spotkin, and cool to see you using flutter :) 

This PR edits `main.dart` to load a different `config.json` based on what environment the website is being run in. This fixes a bug when trying to use your currently deployed version of spotkin_flutter; where after auth'ing against spotify, the redirect goes to `localhost`. 

Whether flutter is running in `release` or `dev` mode can be determined with the following line (see [here](https://stackoverflow.com/questions/54023991/difference-between-methods-of-determining-debug-or-release-in-dart)):

```
const bool isProduction = bool.fromEnvironment('dart.vm.product');
```

If you create a new `config_prod.json` with the redirect URL being the deployed firebase URL, then your deployed website should work fine! Already added `config_prod.json` to `pubspec.yaml` and `.gitignore` too. Note that you may need to add the deployed website URL to spotify's redirect allow list.

Thanks and hello from sunny Australia!

Hamish