### PR TITLE
Scope issue

### DIFF
--- a/assets/config.json.example
+++ b/assets/config.json.example
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flutter Web",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "args": [
+        "--web-port",
+        "8888"
+      ]
+    }
+  ],
+    "SPOTIFY_CLIENT_ID": "",
+    "SPOTIFY_CLIENT_SECRET": "",
+    "SPOTIFY_REDIRECT_URI": "",
+    "SPOTIFY_SCOPE": "playlist-modify-private playlist-modify-public user-library-read playlist-read-private user-library-modify user-read-recently-played",
+    "BACKEND_URL": ""
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,7 +148,7 @@ class _MyHomePageState extends State<MyHomePage> {
       'client_id': Uri.encodeFull(clientId),
       'response_type': 'code',
       'redirect_uri': Uri.encodeFull(redirectUri),
-      'scope': Uri.encodeFull(scope),
+      'scope': scope,
     });
 
     print('Redirecting to: $spotifyAuthUrl');


### PR DESCRIPTION
Hey good morning,

I see in the README: `Currently deployed at https://spotkin-fd416.web.app/ though the Spotify login is not working (due to the redirect URI not being set up correctly?). Running locally works, however.`

I've tried out the deployed login flow at [spotkin-fd416.web.app](https://spotkin-fd416.web.app/)

After I confirmed to access my Spotify account, I see the next request fails because `INVALID_SCOPE: Invalid scope`

Here is the scope in that request: `playlist-modify-private%20playlist-modify-public%20user-library-read%20playlist-read-private%20user-library-modify%20user-read-recently-played` 

Plain without encoding:
`playlist-modify-private playlist-modify-public user-library-read playlist-read-private user-library-modify user-read-recently-played`

I got the flutter app running locally, and put the same scopes in my config. I get the same `INVALID_SCOPE: Invalid scope` in my login flow locally.

If I change the scope value to just be plain, it works. 
Could you this out in the deployed environment?

I also included a `config.json.example` template, because it took me a little while to figure out how `widget.config['SPOTIFY_CLIENT_ID']` worked. So this is a little help for the Flutter noobs like me.