### PR TITLE
Add debouncer to SearchBottomSheet

### DIFF
--- a/lib/widgets/bottom_sheets/search_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/search_bottom_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:spotify/spotify.dart' hide Image;
 import 'package:spotkin_flutter/app_core.dart';
@@ -29,6 +31,7 @@ class _SearchBottomSheetState extends State<SearchBottomSheet> {
   final SpotifyService spotifyService = getIt<SpotifyService>();
   List<dynamic> _searchResults = [];
   bool _isLoading = false;
+  Timer? _debounceTimer;
 
   @override
   void initState() {
@@ -39,11 +42,20 @@ class _SearchBottomSheetState extends State<SearchBottomSheet> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _searchController.addListener(() {
           if (_searchController.text.isNotEmpty) {
-            _performSearch();
+            _debounceSearch();
           }
         });
       });
     }
+  }
+
+  void _debounceSearch() {
+    if (_debounceTimer != null) {
+      _debounceTimer!.cancel();
+    }
+    _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+      _performSearch();
+    });
   }
 
   void _fetchUserPlaylists() async {
@@ -211,6 +223,13 @@ class _SearchBottomSheetState extends State<SearchBottomSheet> {
                   ),
       ],
     );
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _debounceTimer?.cancel();
+    super.dispose();
   }
 
   //   return Container(


### PR DESCRIPTION
Hello Rivers,

I've added a bouncer/timer to the search bottom seach component, so that the results aren't refreshed at every key stroke, and only send a request to the spotify API once the user is done typing.

this helps reduce the number of API requests sent (searching for "run raven run" sent 13 requests) and the number of refreshes by a lot, making the navigation feel much smoother.

## Before:
![Peek 2024-08-04 10-45](https://github.com/user-attachments/assets/535c7a50-bc7b-45d5-b803-ba1846ade7ed)

## Now, with the debouncer:
![Peek 2024-08-04 10-40](https://github.com/user-attachments/assets/b58b7d30-e838-414c-980a-82d84bf956ae)

thank you,
Urbain