### PR TITLE
Add RecipeWidget.onIngredientsChanged callback

### DIFF
--- a/lib/widgets/recipe_widget.dart
+++ b/lib/widgets/recipe_widget.dart
@@ -65,6 +65,8 @@ class _RecipeWidgetState extends State<RecipeWidget> {
         quantityController: TextEditingController(),
       ));
     });
+
+    widget.onIngredientsChanged([...job.recipe, newIngredient]);
   }
 
   void _initIngredientRows() {
@@ -136,6 +138,8 @@ class _RecipeWidgetState extends State<RecipeWidget> {
       final updatedJob = job.copyWith(recipe: updatedRecipe);
       storageService.updateJob(updatedJob);
     });
+
+    widget.onIngredientsChanged(storageService.getJobs().first.recipe);
   }
 
   Widget buildQuantityDropdown(IngredientRow row, int index) {
@@ -155,6 +159,7 @@ class _RecipeWidgetState extends State<RecipeWidget> {
               row.quantityController.text = value.toString();
               _updateJobInStorage(index, value);
             });
+            widget.onIngredientsChanged(storageService.getJobs().first.recipe);
           }
         },
         validator: (value) {


### PR DESCRIPTION
Hey Rivers,
another quick PR to fix the issue where the green 'Update' button on the bottom navigation bar wouldn't appear after all the requirements were met for it to display (job is created and has at least one non-empty recipe).

a `onIngredientsChanged` callback was already handled and did everything needed to update the jobs state, but that callback was never called in the Recipe Widget, so I've added these calls when a new row is created, deleted and updated.

now the button seems to work as expected.
![Peek 2024-08-05 14-38](https://github.com/user-attachments/assets/e16c7308-04f4-4722-8032-712ed5a52203)

hope this helps. thank you.