### PR TITLE
restore correct text color

### DIFF
--- a/lib/widgets/bottom_sheets/spotkin_info_content.dart
+++ b/lib/widgets/bottom_sheets/spotkin_info_content.dart
@@ -35,6 +35,7 @@ final infoSheetContent = [
       children: [
         TextSpan(
           text: '• New releases from genres you love via the ',
+          style: TextStyle(color: Colors.white70),
           ),
           TextSpan(
             text: 'new_albums script',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -457,12 +457,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-
       sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
     version: "14.2.4"
-
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
This should restore the correct color for the section of text that defaulted to black on the info sheet

I set it to white70 which is the color for bodyMedium in theme data.